### PR TITLE
using uint64 instead of float64 as ByteSize type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 ByteSize
 ========
 
+This is a fork of https://github.com/inhies/go-bytesize
+This ByteSize fork uses an uint64 instead of a float64 for storing the byte sizes. As bytes are always natural numbers
+an integer representation is desirable. You do not have to deal with floating point inaccuracy. The disadvantage
+is that you are limited to sizes up to 2^64. So this fork does not support ZB and YB sizes. The biggest supported
+size is 18.4EB.
+
 Bytesize is a package for working with measurements of bytes. Using this package
 allows you to easily add 100KB to 4928MB and get a nicely formatted string
 representation of the result.
 
-[![GoDoc](http://godoc.org/github.com/inhies/go-bytesize?status.png)](http://godoc.org/github.com/inhies/go-bytesize)
-[![Build Status](https://travis-ci.org/inhies/go-bytesize.png)](https://travis-ci.org/inhies/go-bytesize)
-[![Coverage Status](https://coveralls.io/repos/inhies/go-bytesize/badge.png)](https://coveralls.io/r/inhies/go-bytesize)
-
+[![GoDoc](http://godoc.org/github.com/MalteJ/go-bytesize?status.png)](http://godoc.org/github.com/MalteJ/go-bytesize)
+[![Build Status](https://travis-ci.org/MalteJ/go-bytesize.png)](https://travis-ci.org/MalteJ/go-bytesize)
+[![Coverage Status](https://coveralls.io/repos/MalteJ/go-bytesize/badge.svg?branch=master&service=github)](https://coveralls.io/github/MalteJ/go-bytesize?branch=master)
 
 Usage
 -----

--- a/bytesize.go
+++ b/bytesize.go
@@ -22,7 +22,7 @@ import (
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 // ByteSize represents a number of bytes
-type ByteSize float64
+type ByteSize uint64
 
 // Byte size size suffixes.
 const (
@@ -33,8 +33,6 @@ const (
 	TB
 	PB
 	EB
-	ZB
-	YB
 )
 
 // Used for returning long unit form of string representation.
@@ -46,8 +44,6 @@ var longUnitMap = map[ByteSize]string{
 	TB: "terabyte",
 	PB: "petabyte",
 	EB: "exabyte",
-	ZB: "zettabyte",
-	YB: "yottabyte",
 }
 
 // Used for returning string representation.
@@ -59,8 +55,6 @@ var shortUnitMap = map[ByteSize]string{
 	TB: "TB",
 	PB: "PB",
 	EB: "EB",
-	ZB: "ZB",
-	YB: "YB",
 }
 
 // Used to convert user input to ByteSize
@@ -92,14 +86,6 @@ var unitMap = map[string]ByteSize{
 	"EB":       EB,
 	"EXABYTE":  EB,
 	"EXABYTES": EB,
-
-	"ZB":         ZB,
-	"ZETTABYTE":  ZB,
-	"ZETTABYTES": ZB,
-
-	"YB":         YB,
-	"YOTTABYTE":  YB,
-	"YOTTABYTES": YB,
 }
 
 var (
@@ -113,7 +99,7 @@ var (
 
 // Parse parses a byte size string. A byte size string is a number followed by
 // a unit suffix, such as "1024B" or "1 MB". Valid byte units are "B", "KB",
-// "MB", "GB", "TB", "PB", "EB", "ZB", and "YB". You can also use the long
+// "MB", "GB", "TB", "PB" and "EB". You can also use the long
 // format of units, such as "kilobyte" or "kilobytes".
 func Parse(s string) (ByteSize, error) {
 	// Remove leading and trailing whitespace
@@ -190,10 +176,6 @@ func (b ByteSize) format(format string, unit string, longUnits bool) string {
 		}
 	} else {
 		switch {
-		case b >= YB:
-			unitSize = YB
-		case b >= ZB:
-			unitSize = ZB
 		case b >= EB:
 			unitSize = EB
 		case b >= PB:
@@ -213,11 +195,11 @@ func (b ByteSize) format(format string, unit string, longUnits bool) string {
 
 	if longUnits {
 		var s string
-		value := fmt.Sprintf(format, b/unitSize)
+		value := fmt.Sprintf(format, float64(b)/float64(unitSize))
 		if printS, _ := strconv.ParseFloat(strings.TrimSpace(value), 64); printS > 0 && printS != 1 {
 			s = "s"
 		}
-		return fmt.Sprintf(format+longUnitMap[unitSize]+s, b/unitSize)
+		return fmt.Sprintf(format+longUnitMap[unitSize]+s, float64(b)/float64(unitSize))
 	}
-	return fmt.Sprintf(format+shortUnitMap[unitSize], b/unitSize)
+	return fmt.Sprintf(format+shortUnitMap[unitSize], float64(b)/float64(unitSize))
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -45,8 +45,6 @@ var newTable = []struct {
 	{1099511627776, "1.00TB"},
 	{1125899906842624, "1.00PB"},
 	{1152921504606846976, "1.00EB"},
-	{1180591620717411303424, "1.00ZB"},
-	{1208925819614629174706176, "1.00YB"},
 }
 
 func Test_New(t *testing.T) {
@@ -70,8 +68,6 @@ var globalFormatTable = []struct {
 	{1099511627776, "1 terabyte"},
 	{1125899906842624, "1 petabyte"},
 	{1152921504606846976, "1 exabyte"},
-	{1180591620717411303424, "1 zettabyte"},
-	{1208925819614629174706176, "1 yottabyte"},
 	{2 * 1, "2 bytes"},
 	{2 * 1024, "2 kilobytes"},
 	{2 * 1048576, "2 megabytes"},
@@ -79,8 +75,6 @@ var globalFormatTable = []struct {
 	{2 * 1099511627776, "2 terabytes"},
 	{2 * 1125899906842624, "2 petabytes"},
 	{2 * 1152921504606846976, "2 exabytes"},
-	{2 * 1180591620717411303424, "2 zettabytes"},
-	{2 * 1208925819614629174706176, "2 yottabytes"},
 }
 
 func Test_GlobalFormat(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -2,7 +2,7 @@ package bytesize_test
 
 import (
 	"fmt"
-	"github.com/inhies/go-bytesize"
+	"github.com/MalteJ/go-bytesize"
 )
 
 func ExampleNew() {


### PR DESCRIPTION
I like this a lot. I only used float64 at the time due to inexperience with Go. I agree that a uint64 is the way to go.